### PR TITLE
Fix log-scale title formatting

### DIFF
--- a/mann_kendall/ui/visualizer.py
+++ b/mann_kendall/ui/visualizer.py
@@ -106,9 +106,10 @@ def create_trend_plot(results: pd.DataFrame, dataframe: pd.DataFrame) -> None:
                 df_plot[log_component_name] = np.log10(df_plot[log_component_name])
                 
                 # Add a note about replacement to the chart title
-                title =(
-                    f"""{', '.join(desired_wells)} x {desired_component} 
-                    d(log scale with replaced values)""")
+                title = (
+                    f"{', '.join(desired_wells)} x {desired_component} "
+                    "(log scale with replaced values)"
+                )
                 plot_component = log_component_name
             else:
                 # No replacement needed, just log transform


### PR DESCRIPTION
## Summary
- clean up title formatting when log scale uses replacements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843640abc50832481c55b711572dca1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved formatting of plot titles for log scale plots by removing unnecessary newlines and extra whitespace. The information displayed remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->