### PR TITLE
Deprecate Python 3.8 and 3.9 in CI matrix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
Update the Python version matrix in the CI configuration to remove support for deprecated versions 3.8 and 3.9, ensuring compatibility with newer versions.